### PR TITLE
Fix the community workflow failing

### DIFF
--- a/.github/workflows/jdstudio_Community.yml
+++ b/.github/workflows/jdstudio_Community.yml
@@ -1,7 +1,7 @@
 on:
   fork:
   push:
-    branches: [develop]
+    branches: [main]
   issues:
     types: [opened]
   issue_comment:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: jaidevstudio/gh-action-community/src/welcome@main
+      - uses: EddieHubCommunity/gh-action-community/src/welcome@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: '<h1>It''s great having you contribute to this project</h1> Welcome to the community :nerd_face:'
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: jaidevstudio/gh-action-community/src/statistics@main
+      - uses: EddieHubCommunity/gh-action-community/src/statistics@main
         if: ${{ github.repository_owner == 'jaidevstudio' }}
         with:
           firebase-key: ${{ secrets.FIREBASE_KEY }}


### PR DESCRIPTION
Things added/changed:

- Fix the community workflow failing.
  - Closes #36.
  - For now, we can use the action from [**Eddie Hub**](https://github.com/EddieHubCommunity/gh-action-community/) as long as @eddiejaoude has no problem with it. 🙂
